### PR TITLE
Fix to make Audio Tour reflect original code

### DIFF
--- a/runestone/activecode/js/activecode.js
+++ b/runestone/activecode/js/activecode.js
@@ -216,7 +216,7 @@ ActiveCode.prototype.createControls = function () {
         $(butt).css("margin-left", "10px");
         this.atButton = butt;
         ctrlDiv.appendChild(butt);
-        $(butt).click((function() {new AudioTour(this.divid, this.editor.getValue(), 1, $(this.origElem).data("audio"))}).bind(this));
+        $(butt).click((function() {new AudioTour(this.divid, this.code, 1, $(this.origElem).data("audio"))}).bind(this));
     }
 
 


### PR DESCRIPTION
When the user chooses to start an Audio Tour for some code, the text box in the Tour reflects the user-edited code and not the original code. As a result, there may be a disparity between what is being said in the audio and what is being displayed in the text box. The fix ensures that the Audio Tour text box always reflects the original code.